### PR TITLE
Issue #5: Add photo starring feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ DerivedData/
 *.dmg
 *.pkg
 *.zip
+.kiro
+.kiro/**

--- a/AGENT.md
+++ b/AGENT.md
@@ -11,12 +11,13 @@
 All implementation tasks (Tasks 1-11) have been completed:
 - ✅ Project structure and setup
 - ✅ Core data models
-- ✅ Service layer (ConfigurationService, ImageLoaderService)
+- ✅ Service layer (ConfigurationService, ImageLoaderService, StarringService)
 - ✅ ViewModel implementation
 - ✅ SwiftUI views (MainView, SlideshowDisplayView, ControlPanelView, ConfigurationView)
 - ✅ Comprehensive test coverage (unit tests + property-based tests)
 - ✅ Distribution scripts (app bundle and DMG creation)
 - ✅ **Multiple instance support**: Each instance has isolated configuration and can run independently
+- ✅ **Photo starring feature**: Star/unstar photos, filter by starred status, keyboard shortcuts
 
 ### Build Status
 
@@ -53,7 +54,8 @@ ImageSlideshow/
 │   │   │   └── ConfigurationView.swift
 │   │   └── Services/
 │   │       ├── ImageLoaderService.swift
-│   │       └── ConfigurationService.swift
+│   │       ├── ConfigurationService.swift
+│   │       └── StarringService.swift
 │   └── ImageSlideshowApp/       # Executable target
 │       └── main.swift
 ├── Tests/
@@ -63,7 +65,8 @@ ImageSlideshow/
 │       │   ├── ConfigurationViewTests.swift
 │       │   ├── ControlPanelViewTests.swift
 │       │   ├── ImageLoaderServiceTests.swift
-│       │   └── SlideshowViewModelTests.swift
+│       │   ├── SlideshowViewModelTests.swift
+│       │   └── StarringServiceTests.swift
 │       └── PropertyTests/
 │           ├── ConfigurationPropertyTests.swift
 │           ├── ImageLoadingPropertyTests.swift
@@ -101,18 +104,27 @@ The project uses a dual-target structure:
    - Play/Pause
    - Next/Previous navigation
    - Keyboard shortcuts support
+   - Star/Unstar controls (button and keyboard shortcuts)
 
-4. **Image Display**
+4. **Photo Starring** ⭐
+   - Star and unstar individual photos when slideshow is paused or idle
+   - Visual indicators: star button in control panel and star overlay on images
+   - Keyboard shortcuts: "s" to star/unstar, "u" to unstar
+   - Per-folder starred state persistence (via StarringService)
+   - Filter toggle to show only starred photos
+   - Starred state persists across app restarts
+
+5. **Image Display**
    - Aspect ratio preservation
    - Aspect-fit scaling
    - Full-screen display
 
-5. **Error Handling**
+6. **Error Handling**
    - Graceful handling of corrupted images
    - Error logging with filename information
    - Automatic recovery and continuation
 
-6. **Multiple Instance Support**
+7. **Multiple Instance Support**
    - Run multiple slideshow instances simultaneously
    - Each instance has isolated configuration (transition duration, effect, folder selection)
    - Instance-specific UserDefaults keys prevent configuration conflicts
@@ -144,6 +156,7 @@ The project uses a dual-target structure:
   - ControlPanelViewTests
   - ImageLoaderServiceTests
   - SlideshowViewModelTests
+  - StarringServiceTests
 
 - **Property-Based Tests**: Comprehensive property validation
   - ConfigurationPropertyTests (Property 8)
@@ -294,6 +307,7 @@ The project is complete, but potential enhancements could include:
    - Playlist support
    - Image metadata display
    - Export functionality
+   - Starred photos export/import
 
 ## Key Takeaways for Agents
 
@@ -304,6 +318,7 @@ The project is complete, but potential enhancements could include:
 5. **Distribution Ready**: Scripts available for creating distributable packages
 6. **Documentation Complete**: All major aspects are documented
 7. **Multiple Instance Support**: Each instance has isolated configuration, allowing multiple slideshows to run simultaneously
+8. **Photo Starring**: Complete starring feature with UI controls, keyboard shortcuts, filtering, and per-folder persistence
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
 # ImageSlideshow
+
+A native macOS application for displaying configurable image slideshows with photo starring capabilities.
+
+## Features
+
+### Core Functionality
+
+1. **Folder-based Image Selection**
+   - Select a folder containing images
+   - Automatic filtering of supported formats (jpg, jpeg, png, gif, heic, tiff, bmp)
+   - Alphabetical ordering of images
+
+2. **Configurable Slideshow**
+   - Transition duration: 1-60 seconds
+   - Transition effects: slide, none
+   - Configuration persistence across sessions
+
+3. **Playback Controls**
+   - Play/Pause
+   - Next/Previous navigation
+   - Keyboard shortcuts support
+
+4. **Photo Starring** ⭐
+   - Star and unstar individual photos when slideshow is paused or idle
+   - Visual indicators: star button in control panel and star overlay on images
+   - Keyboard shortcuts: "s" to star/unstar, "u" to unstar
+   - Per-folder starred state persistence
+   - Filter to show only starred photos
+
+5. **Image Display**
+   - Aspect ratio preservation
+   - Aspect-fit scaling
+   - Full-screen display
+
+6. **Error Handling**
+   - Graceful handling of corrupted images
+   - Error logging with filename information
+   - Automatic recovery and continuation
+
+7. **Multiple Instance Support**
+   - Run multiple slideshow instances simultaneously
+   - Each instance has isolated configuration
+
+## Photo Starring Feature
+
+### How to Use
+
+1. **Starring Photos**
+   - Load a folder with images
+   - Pause the slideshow (or keep it in idle state)
+   - Click the star button in the control panel, or press "s" key
+   - The star icon will fill yellow to indicate the photo is starred
+   - A star overlay will appear in the top-right corner of the image
+
+2. **Unstarring Photos**
+   - With a starred photo displayed, click the star button again, or press "s" key
+   - Press "u" key to unstar (only works when paused/idle)
+   - The star icon will return to outline and the overlay will disappear
+
+3. **Filtering Starred Photos**
+   - Go to Settings panel (left sidebar)
+   - Toggle "Show only starred photos"
+   - The slideshow will only display photos you've starred
+   - Toggle off to show all photos again
+
+4. **Starred State Persistence**
+   - Starred state is saved per folder
+   - Your starred photos persist across app restarts
+   - Each folder maintains its own independent set of starred photos
+
+### Keyboard Shortcuts
+
+- **Space**: Play/Pause slideshow
+- **Left Arrow**: Previous image
+- **Right Arrow**: Next image
+- **s**: Star/Unstar current image (only when paused/idle)
+- **u**: Unstar current image (only when paused/idle)
+
+## Building and Running
+
+### Build
+```bash
+swift build
+```
+
+### Run
+```bash
+swift run ImageSlideshow
+```
+
+## Requirements
+
+- macOS 13.0 or later
+- Swift 5.9 or later
+
+## Project Structure
+
+- `Sources/ImageSlideshow/`: Core library with models, views, view models, and services
+- `Sources/ImageSlideshowApp/`: Application entry point
+- `Tests/`: Comprehensive test suite
+
+For detailed documentation, see `AGENT.md`.

--- a/Sources/ImageSlideshow/Models/SlideshowConfiguration.swift
+++ b/Sources/ImageSlideshow/Models/SlideshowConfiguration.swift
@@ -17,18 +17,24 @@ public struct SlideshowConfiguration: Codable, Equatable {
     /// Path to the last selected folder, if any
     public var lastSelectedFolderPath: String?
     
+    /// Whether to show only starred photos in the slideshow
+    public var showOnlyStarred: Bool
+    
     /// Creates a new slideshow configuration
     /// - Parameters:
     ///   - transitionDuration: Duration between transitions (default: 5.0 seconds)
     ///   - transitionEffect: Transition effect to apply (default: .none)
     ///   - lastSelectedFolderPath: Optional path to last selected folder
+    ///   - showOnlyStarred: Whether to show only starred photos (default: false)
     public init(
         transitionDuration: TimeInterval = 5.0,
         transitionEffect: TransitionEffect = .none,
-        lastSelectedFolderPath: String? = nil
+        lastSelectedFolderPath: String? = nil,
+        showOnlyStarred: Bool = false
     ) {
         self.transitionDuration = transitionDuration
         self.transitionEffect = transitionEffect
         self.lastSelectedFolderPath = lastSelectedFolderPath
+        self.showOnlyStarred = showOnlyStarred
     }
 }

--- a/Sources/ImageSlideshow/Services/ConfigurationService.swift
+++ b/Sources/ImageSlideshow/Services/ConfigurationService.swift
@@ -22,6 +22,7 @@ public class UserDefaultsConfigurationService: ConfigurationService {
         static let transitionDuration = "transitionDuration"
         static let transitionEffect = "transitionEffect"
         static let lastFolderPath = "lastFolderPath"
+        static let showOnlyStarred = "showOnlyStarred"
     }
     
     // Default configuration values
@@ -56,6 +57,7 @@ public class UserDefaultsConfigurationService: ConfigurationService {
         userDefaults.set(config.transitionDuration, forKey: makeKey(BaseKeys.transitionDuration))
         userDefaults.set(config.transitionEffect.rawValue, forKey: makeKey(BaseKeys.transitionEffect))
         userDefaults.set(config.lastSelectedFolderPath, forKey: makeKey(BaseKeys.lastFolderPath))
+        userDefaults.set(config.showOnlyStarred, forKey: makeKey(BaseKeys.showOnlyStarred))
     }
     
     public func loadConfiguration() -> SlideshowConfiguration {
@@ -81,10 +83,14 @@ public class UserDefaultsConfigurationService: ConfigurationService {
         // Load last folder path (optional)
         let lastFolderPath = userDefaults.string(forKey: makeKey(BaseKeys.lastFolderPath))
         
+        // Load showOnlyStarred (defaults to false if not found)
+        let showOnlyStarred = userDefaults.bool(forKey: makeKey(BaseKeys.showOnlyStarred))
+        
         return SlideshowConfiguration(
             transitionDuration: transitionDuration,
             transitionEffect: transitionEffect,
-            lastSelectedFolderPath: lastFolderPath
+            lastSelectedFolderPath: lastFolderPath,
+            showOnlyStarred: showOnlyStarred
         )
     }
 }

--- a/Sources/ImageSlideshow/Services/StarringService.swift
+++ b/Sources/ImageSlideshow/Services/StarringService.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Protocol for managing starred image state persistence
+public protocol StarringService {
+    /// Marks an image as starred in the specified folder
+    /// - Parameters:
+    ///   - imageUrl: The URL of the image to star
+    ///   - folderPath: The path of the folder containing the image
+    func starImage(at imageUrl: URL, inFolder folderPath: String)
+    
+    /// Removes the starred status from an image in the specified folder
+    /// - Parameters:
+    ///   - imageUrl: The URL of the image to unstar
+    ///   - folderPath: The path of the folder containing the image
+    func unstarImage(at imageUrl: URL, inFolder folderPath: String)
+    
+    /// Checks if an image is starred in the specified folder
+    /// - Parameters:
+    ///   - imageUrl: The URL of the image to check
+    ///   - folderPath: The path of the folder containing the image
+    /// - Returns: True if the image is starred, false otherwise
+    func isStarred(imageUrl: URL, inFolder folderPath: String) -> Bool
+    
+    /// Gets all starred image URLs for a specific folder
+    /// - Parameter folderPath: The path of the folder
+    /// - Returns: Set of image URLs that are starred in this folder
+    func getStarredImageUrls(forFolder folderPath: String) -> Set<URL>
+}
+
+/// Implementation of StarringService using UserDefaults
+public class UserDefaultsStarringService: StarringService {
+    private let userDefaults: UserDefaults
+    
+    /// Initializes the starring service
+    /// - Parameter userDefaults: The UserDefaults instance to use (defaults to .standard)
+    public init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+    
+    /// Generates a UserDefaults key for starred images in a folder
+    /// - Parameter folderPath: The folder path
+    /// - Returns: The key for storing starred images for this folder
+    private func makeKey(forFolder folderPath: String) -> String {
+        // Normalize the folder path to ensure consistent keys
+        let normalizedPath = (folderPath as NSString).standardizingPath
+        return "starred.\(normalizedPath)"
+    }
+    
+    /// Gets the set of starred image URLs for a folder
+    /// - Parameter folderPath: The folder path
+    /// - Returns: Set of image URL paths (as strings) that are starred
+    private func getStarredImagePaths(forFolder folderPath: String) -> Set<String> {
+        let key = makeKey(forFolder: folderPath)
+        if let array = userDefaults.array(forKey: key) as? [String] {
+            return Set(array)
+        }
+        return Set<String>()
+    }
+    
+    /// Saves the set of starred image paths for a folder
+    /// - Parameters:
+    ///   - starredPaths: The set of image paths to save
+    ///   - folderPath: The folder path
+    private func saveStarredImagePaths(_ starredPaths: Set<String>, forFolder folderPath: String) {
+        let key = makeKey(forFolder: folderPath)
+        if starredPaths.isEmpty {
+            // Remove the key if no starred images
+            userDefaults.removeObject(forKey: key)
+        } else {
+            userDefaults.set(Array(starredPaths), forKey: key)
+        }
+    }
+    
+    public func starImage(at imageUrl: URL, inFolder folderPath: String) {
+        var starredPaths = getStarredImagePaths(forFolder: folderPath)
+        // Use the absolute path as the identifier
+        let imagePath = imageUrl.path
+        starredPaths.insert(imagePath)
+        saveStarredImagePaths(starredPaths, forFolder: folderPath)
+    }
+    
+    public func unstarImage(at imageUrl: URL, inFolder folderPath: String) {
+        var starredPaths = getStarredImagePaths(forFolder: folderPath)
+        let imagePath = imageUrl.path
+        starredPaths.remove(imagePath)
+        saveStarredImagePaths(starredPaths, forFolder: folderPath)
+    }
+    
+    public func isStarred(imageUrl: URL, inFolder folderPath: String) -> Bool {
+        let starredPaths = getStarredImagePaths(forFolder: folderPath)
+        let imagePath = imageUrl.path
+        return starredPaths.contains(imagePath)
+    }
+    
+    public func getStarredImageUrls(forFolder folderPath: String) -> Set<URL> {
+        let starredPaths = getStarredImagePaths(forFolder: folderPath)
+        return Set(starredPaths.compactMap { URL(fileURLWithPath: $0) })
+    }
+}
+

--- a/Sources/ImageSlideshow/Views/ConfigurationView.swift
+++ b/Sources/ImageSlideshow/Views/ConfigurationView.swift
@@ -7,12 +7,14 @@ struct ConfigurationView: View {
     // Local state for editing configuration
     @State private var transitionDuration: Double
     @State private var transitionEffect: TransitionEffect
+    @State private var showOnlyStarred: Bool
     
     init(viewModel: SlideshowViewModel) {
         self.viewModel = viewModel
         // Initialize state from current configuration
         _transitionDuration = State(initialValue: viewModel.configuration.transitionDuration)
         _transitionEffect = State(initialValue: viewModel.configuration.transitionEffect)
+        _showOnlyStarred = State(initialValue: viewModel.configuration.showOnlyStarred)
     }
     
     var body: some View {
@@ -58,6 +60,15 @@ struct ConfigurationView: View {
                 }
             }
             
+            // Show Only Starred Toggle
+            VStack(alignment: .leading, spacing: 8) {
+                Toggle("Show only starred photos", isOn: $showOnlyStarred)
+                    .font(.subheadline)
+                    .onChange(of: showOnlyStarred) { _ in
+                        applyConfiguration()
+                    }
+            }
+            
             Spacer()
         }
         .padding()
@@ -69,7 +80,8 @@ struct ConfigurationView: View {
         let newConfig = SlideshowConfiguration(
             transitionDuration: transitionDuration,
             transitionEffect: transitionEffect,
-            lastSelectedFolderPath: viewModel.configuration.lastSelectedFolderPath
+            lastSelectedFolderPath: viewModel.configuration.lastSelectedFolderPath,
+            showOnlyStarred: showOnlyStarred
         )
         viewModel.updateConfiguration(newConfig)
     }

--- a/Sources/ImageSlideshow/Views/ControlPanelView.swift
+++ b/Sources/ImageSlideshow/Views/ControlPanelView.swift
@@ -16,6 +16,21 @@ struct ControlPanelView: View {
             
             Spacer()
             
+            // Star button (always visible to show status, but only functional when paused)
+            Button(action: {
+                if viewModel.isCurrentImageStarred {
+                    viewModel.unstarCurrentImage()
+                } else {
+                    viewModel.starCurrentImage()
+                }
+            }) {
+                Image(systemName: viewModel.isCurrentImageStarred ? "star.fill" : "star")
+                    .font(.title2)
+                    .foregroundColor(viewModel.isCurrentImageStarred ? .yellow : .primary)
+            }
+            .help(viewModel.isCurrentImageStarred ? "Unstar image (s key, only when paused)" : "Star image (s key, only when paused)")
+            .disabled(viewModel.images.isEmpty || viewModel.currentImage == nil || (viewModel.state != .paused && viewModel.state != .idle))
+            
             // Previous button
             Button(action: {
                 Task {

--- a/Sources/ImageSlideshow/Views/SlideshowDisplayView.swift
+++ b/Sources/ImageSlideshow/Views/SlideshowDisplayView.swift
@@ -14,16 +14,36 @@ struct SlideshowDisplayView: View {
                 
                 // Display current image if available
                 if let nsImage = viewModel.currentImage {
-                    Image(nsImage: nsImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(
-                            width: geometry.size.width,
-                            height: geometry.size.height
-                        )
-                        .transition(transitionForEffect(viewModel.configuration.transitionEffect))
-                        .id(viewModel.currentIndex) // Key for transitions
-                        .animation(.easeInOut(duration: 0.5), value: viewModel.currentIndex)
+                    ZStack {
+                        Image(nsImage: nsImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(
+                                width: geometry.size.width,
+                                height: geometry.size.height
+                            )
+                            .transition(transitionForEffect(viewModel.configuration.transitionEffect))
+                            .id(viewModel.currentIndex) // Key for transitions
+                            .animation(.easeInOut(duration: 0.5), value: viewModel.currentIndex)
+                        
+                        // Starred indicator in top-right corner
+                        if viewModel.isCurrentImageStarred {
+                            VStack {
+                                HStack {
+                                    Spacer()
+                                    Image(systemName: "star.fill")
+                                        .font(.title)
+                                        .foregroundColor(.yellow)
+                                        .padding(16)
+                                        .background(
+                                            Circle()
+                                                .fill(Color.black.opacity(0.5))
+                                        )
+                                }
+                                Spacer()
+                            }
+                        }
+                    }
                 } else {
                     // Placeholder when no image is loaded
                     Text("No image loaded")
@@ -31,6 +51,7 @@ struct SlideshowDisplayView: View {
                 }
             }
         }
+        .focusable()
     }
     
     /// Returns the appropriate SwiftUI transition based on the configuration

--- a/Tests/ImageSlideshowTests/UnitTests/StarringServiceTests.swift
+++ b/Tests/ImageSlideshowTests/UnitTests/StarringServiceTests.swift
@@ -1,0 +1,252 @@
+import XCTest
+@testable import ImageSlideshowLib
+
+final class StarringServiceTests: XCTestCase {
+    
+    // MARK: - Test Starring and Unstarring
+    
+    func testStarImage() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.star.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let service = UserDefaultsStarringService(userDefaults: testDefaults)
+        let folderPath = "/Users/test/Pictures"
+        let imageUrl = URL(fileURLWithPath: "/Users/test/Pictures/image1.jpg")
+        
+        // Star the image
+        service.starImage(at: imageUrl, inFolder: folderPath)
+        
+        // Verify it's starred
+        XCTAssertTrue(service.isStarred(imageUrl: imageUrl, inFolder: folderPath), "Image should be starred")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+    
+    func testUnstarImage() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.unstar.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let service = UserDefaultsStarringService(userDefaults: testDefaults)
+        let folderPath = "/Users/test/Pictures"
+        let imageUrl = URL(fileURLWithPath: "/Users/test/Pictures/image1.jpg")
+        
+        // Star the image first
+        service.starImage(at: imageUrl, inFolder: folderPath)
+        XCTAssertTrue(service.isStarred(imageUrl: imageUrl, inFolder: folderPath), "Image should be starred")
+        
+        // Unstar the image
+        service.unstarImage(at: imageUrl, inFolder: folderPath)
+        
+        // Verify it's not starred
+        XCTAssertFalse(service.isStarred(imageUrl: imageUrl, inFolder: folderPath), "Image should not be starred")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+    
+    func testIsStarredReturnsFalseForUnstarredImage() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.unstarred.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let service = UserDefaultsStarringService(userDefaults: testDefaults)
+        let folderPath = "/Users/test/Pictures"
+        let imageUrl = URL(fileURLWithPath: "/Users/test/Pictures/image1.jpg")
+        
+        // Verify unstarred image returns false
+        XCTAssertFalse(service.isStarred(imageUrl: imageUrl, inFolder: folderPath), "Unstarred image should return false")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+    
+    // MARK: - Test Per-Folder Isolation
+    
+    func testStarredImagesAreIsolatedPerFolder() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.isolation.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let service = UserDefaultsStarringService(userDefaults: testDefaults)
+        let folder1Path = "/Users/test/Pictures1"
+        let folder2Path = "/Users/test/Pictures2"
+        let image1Url = URL(fileURLWithPath: "/Users/test/Pictures1/image1.jpg")
+        let image2Url = URL(fileURLWithPath: "/Users/test/Pictures2/image1.jpg")
+        
+        // Star image in folder 1
+        service.starImage(at: image1Url, inFolder: folder1Path)
+        
+        // Verify it's starred in folder 1
+        XCTAssertTrue(service.isStarred(imageUrl: image1Url, inFolder: folder1Path), "Image should be starred in folder 1")
+        
+        // Verify it's not starred in folder 2 (different folder)
+        XCTAssertFalse(service.isStarred(imageUrl: image1Url, inFolder: folder2Path), "Image should not be starred in folder 2")
+        
+        // Star image in folder 2
+        service.starImage(at: image2Url, inFolder: folder2Path)
+        
+        // Verify both are starred in their respective folders
+        XCTAssertTrue(service.isStarred(imageUrl: image1Url, inFolder: folder1Path), "Image 1 should be starred in folder 1")
+        XCTAssertTrue(service.isStarred(imageUrl: image2Url, inFolder: folder2Path), "Image 2 should be starred in folder 2")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+    
+    // MARK: - Test Get Starred Image URLs
+    
+    func testGetStarredImageUrls() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.getstarred.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let service = UserDefaultsStarringService(userDefaults: testDefaults)
+        let folderPath = "/Users/test/Pictures"
+        let image1Url = URL(fileURLWithPath: "/Users/test/Pictures/image1.jpg")
+        let image2Url = URL(fileURLWithPath: "/Users/test/Pictures/image2.jpg")
+        let image3Url = URL(fileURLWithPath: "/Users/test/Pictures/image3.jpg")
+        
+        // Initially, no starred images
+        var starredUrls = service.getStarredImageUrls(forFolder: folderPath)
+        XCTAssertEqual(starredUrls.count, 0, "Initially no images should be starred")
+        
+        // Star two images
+        service.starImage(at: image1Url, inFolder: folderPath)
+        service.starImage(at: image2Url, inFolder: folderPath)
+        
+        // Get starred URLs
+        starredUrls = service.getStarredImageUrls(forFolder: folderPath)
+        XCTAssertEqual(starredUrls.count, 2, "Should have 2 starred images")
+        XCTAssertTrue(starredUrls.contains(image1Url), "Should contain image1")
+        XCTAssertTrue(starredUrls.contains(image2Url), "Should contain image2")
+        XCTAssertFalse(starredUrls.contains(image3Url), "Should not contain image3")
+        
+        // Unstar one image
+        service.unstarImage(at: image1Url, inFolder: folderPath)
+        
+        // Get starred URLs again
+        starredUrls = service.getStarredImageUrls(forFolder: folderPath)
+        XCTAssertEqual(starredUrls.count, 1, "Should have 1 starred image")
+        XCTAssertFalse(starredUrls.contains(image1Url), "Should not contain image1")
+        XCTAssertTrue(starredUrls.contains(image2Url), "Should contain image2")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+    
+    func testGetStarredImageUrlsReturnsEmptySetForEmptyFolder() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.empty.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let service = UserDefaultsStarringService(userDefaults: testDefaults)
+        let folderPath = "/Users/test/Pictures"
+        
+        // Get starred URLs for folder with no starred images
+        let starredUrls = service.getStarredImageUrls(forFolder: folderPath)
+        XCTAssertEqual(starredUrls.count, 0, "Should return empty set for folder with no starred images")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+    
+    // MARK: - Test Persistence
+    
+    func testStarredStatePersistsAcrossServiceInstances() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.persistence.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let folderPath = "/Users/test/Pictures"
+        let imageUrl = URL(fileURLWithPath: "/Users/test/Pictures/image1.jpg")
+        
+        // Create first service instance and star an image
+        let service1 = UserDefaultsStarringService(userDefaults: testDefaults)
+        service1.starImage(at: imageUrl, inFolder: folderPath)
+        
+        // Create second service instance with same UserDefaults
+        let service2 = UserDefaultsStarringService(userDefaults: testDefaults)
+        
+        // Verify second service can see the starred state
+        XCTAssertTrue(service2.isStarred(imageUrl: imageUrl, inFolder: folderPath), "Starred state should persist across service instances")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+    
+    // MARK: - Test Edge Cases
+    
+    func testUnstarringUnstarredImageDoesNotError() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.unstarred.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let service = UserDefaultsStarringService(userDefaults: testDefaults)
+        let folderPath = "/Users/test/Pictures"
+        let imageUrl = URL(fileURLWithPath: "/Users/test/Pictures/image1.jpg")
+        
+        // Unstar an image that was never starred (should not error)
+        service.unstarImage(at: imageUrl, inFolder: folderPath)
+        
+        // Verify it's still not starred
+        XCTAssertFalse(service.isStarred(imageUrl: imageUrl, inFolder: folderPath), "Unstarring unstarred image should not error")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+    
+    func testStarringSameImageTwice() {
+        // Create a unique UserDefaults suite for this test
+        let suiteName = "test.double.\(UUID().uuidString)"
+        guard let testDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create test UserDefaults")
+            return
+        }
+        
+        let service = UserDefaultsStarringService(userDefaults: testDefaults)
+        let folderPath = "/Users/test/Pictures"
+        let imageUrl = URL(fileURLWithPath: "/Users/test/Pictures/image1.jpg")
+        
+        // Star the image twice
+        service.starImage(at: imageUrl, inFolder: folderPath)
+        service.starImage(at: imageUrl, inFolder: folderPath)
+        
+        // Verify it's still starred (idempotent)
+        XCTAssertTrue(service.isStarred(imageUrl: imageUrl, inFolder: folderPath), "Starring twice should still result in starred state")
+        
+        // Verify only one entry in starred set
+        let starredUrls = service.getStarredImageUrls(forFolder: folderPath)
+        XCTAssertEqual(starredUrls.count, 1, "Should only have one starred image even after starring twice")
+        
+        // Clean up
+        testDefaults.removePersistentDomain(forName: suiteName)
+    }
+}
+


### PR DESCRIPTION
Implements photo starring functionality with the following features:
- Star/unstar individual photos when slideshow is paused or idle
- Visual indicators: star button in control panel and star overlay on images
- Keyboard shortcuts: "s" to star/unstar, "u" to unstar
- Per-folder starred state persistence
- Filter to show only starred photos
- Comprehensive test coverage

Closes #5